### PR TITLE
Add static gradient theme support (black->dark purple)

### DIFF
--- a/SaveManager.lua
+++ b/SaveManager.lua
@@ -57,12 +57,18 @@ local SaveManager = {} do
         },
         Slider = {
             Save = function(idx, object)
-                return { type = "Slider", idx = idx, value = tostring(object.Value) }
+                return { type = "Slider", idx = idx, value = object.Value }
             end,
             Load = function(idx, data)
                 local object = SaveManager.Library.Options[idx]
-                if object and object.Value ~= data.value then
-                    object:SetValue(data.value)
+                if object then
+                    local val = data.value
+                    if type(val) == "string" then
+                        val = tonumber(val) or val
+                    end
+                    if object.Value ~= val then
+                        object:SetValue(val)
+                    end
                 end
             end,
         },
@@ -230,7 +236,11 @@ local SaveManager = {} do
             return false, "failed to encode data"
         end
 
-        writefile(fullPath, encoded)
+        local ok, err = pcall(writefile, fullPath, encoded)
+        if not ok then
+            return false, "write file error: " .. tostring(err)
+        end
+
         return true
     end
 


### PR DESCRIPTION
Implementa soporte de gradientes estáticos (negro → dark purple) para elementos UI y mejoras relacionadas.

Cambios principales:
- Library.lua: helpers de gradiente (CreateGradient, ApplyGradientToInstance), Library.Gradients para almacenar objetos de gradiente, aplicación automática de UIGradient a propiedades registradas; compatibilidad de fallback con Library.Scheme (primer color).
- ThemeManager.lua: el tema por defecto usa ahora un AccentColor en gradiente; ApplyTheme convierte/almacena gradientes en Library.Gradients y mantiene Library.Scheme con un Color3 fallback; SaveCustomTheme serializa gradientes correctamente.
- SaveManager.lua: guardado/carga segura (sliders guardan números no strings), writefile envuelto en pcall y carga tolerante a strings->número.

Detalles de comportamiento:
- El gradiente es estático (no animado) y se aplica mediante UIGradient (child: ObsidianGradient_<Property>).
- Para propiedades que no admiten UIGradient (TextColor3, ImageColor3) se usa el primer color del gradiente como fallback.
- Se preserva compatibilidad con código que espera Color3 en Library.Scheme al mantener siempre un fallback en Library.Scheme y almacenar la definición completa del gradiente en Library.Gradients.

Archivos modificados: Library.lua, ThemeManager.lua, SaveManager.lua.