### PR TITLE
Add gradient UI theme system with GradientDarkPurple theme

### DIFF
--- a/ThemeManager.lua
+++ b/ThemeManager.lua
@@ -51,6 +51,19 @@ do
             1,
             { FontColor = "ffffff", MainColor = "191919", AccentColor = "7d55ff", BackgroundColor = "0f0f0f", OutlineColor = "282828" },
         },
+        ["GradientDarkPurple"] = {
+            0, -- Priority 0 to make it first/default
+            {
+                FontColor = "ffffff",
+                MainColor = "191919",
+                AccentColor = "7d55ff",
+                BackgroundColor = "0f0f0f",
+                OutlineColor = "282828",
+                UseGradients = "true", -- Enable gradients for this theme
+                GradientStart = "000000", -- Black
+                GradientEnd = "4B0082" -- Indigo/Dark Purple
+            },
+        },
         ["BBot"] = {
             2,
             { FontColor = "ffffff", MainColor = "1e1e1e", AccentColor = "7e48a3", BackgroundColor = "232323", OutlineColor = "141414" },
@@ -184,6 +197,12 @@ do
                 if self.Library.Options[idx] then
                     self.Library.Options[idx]:SetValue(val)
                 end
+            elseif idx == "UseGradients" then
+                -- Handle UseGradients as boolean
+                self.Library.Scheme[idx] = (val == "true" or val == true)
+            elseif idx == "GradientStart" or idx == "GradientEnd" then
+                -- Handle gradient colors
+                self.Library.Scheme[idx] = Color3.fromHex(val)
             else
                 self.Library.Scheme[idx] = Color3.fromHex(val)
 
@@ -224,7 +243,7 @@ do
     end
 
     function ThemeManager:LoadDefault()
-        local theme = "Default"
+        local theme = "GradientDarkPurple" -- Default to GradientDarkPurple theme
         local content = isfile(self.Folder .. "/themes/default.txt") and readfile(self.Folder .. "/themes/default.txt")
 
         local isDefault = true
@@ -237,6 +256,9 @@ do
             end
         elseif self.BuiltInThemes[self.DefaultTheme] then
             theme = self.DefaultTheme
+        elseif not self.BuiltInThemes[theme] then
+            -- Fallback to Default if GradientDarkPurple doesn't exist (shouldn't happen)
+            theme = "Default"
         end
 
         if isDefault then
@@ -305,6 +327,15 @@ do
             theme[field] = self.Library.Options[field].Value:ToHex()
         end
         theme["FontFace"] = self.Library.Options["FontFace"].Value
+
+        -- Save gradient settings if enabled
+        if self.Library.Scheme.UseGradients then
+            theme["UseGradients"] = "true"
+            theme["GradientStart"] = self.Library.Scheme.GradientStart:ToHex()
+            theme["GradientEnd"] = self.Library.Scheme.GradientEnd:ToHex()
+        else
+            theme["UseGradients"] = "false"
+        end
 
         writefile(self.Folder .. "/themes/" .. file .. ".json", HttpService:JSONEncode(theme))
     end


### PR DESCRIPTION
Implemented a modern gradient system for UI elements with the following features:

**Library.lua changes:**
- Added gradient support to color scheme (UseGradients, GradientStart, GradientEnd)
- Created GradientRegistry to track gradient elements
- Implemented CreateGradient(), UpdateGradientColors(), UpdateGradients(), and ApplyGradientToElement() functions
- Applied gradients to Toggle switches and Slider fills
- Gradients use smooth 5-keypoint transitions from black (#000000) to dark purple (#4B0082)
- Non-animated, static gradients for modern cyberpunk aesthetic

**ThemeManager.lua changes:**
- Added "GradientDarkPurple" theme with priority 0 (default theme)
- Extended ApplyTheme() to handle gradient-specific fields
- Updated LoadDefault() to use GradientDarkPurple as default
- Modified SaveCustomTheme() to serialize gradient settings

**SaveManager.lua changes:**
- Added gradient fields to ignore list for theme settings
- Implemented debounced save system to prevent excessive writes
- Added config validation and migration support
- Optimized save performance with 0.5s debounce delay

The gradient system is fully compatible with existing themes - gradients only activate when UseGradients is true.